### PR TITLE
getting the file name by os.path.basename 

### DIFF
--- a/bids2openminds/main.py
+++ b/bids2openminds/main.py
@@ -231,8 +231,7 @@ def create_file(layout_df, BIDS_path):
         data_types = None
         extension = file["extension"]
         path = file["path"]
-        path_iri=pathlib.Path(path).as_uri()
-        iri=IRI(path_iri)
+        iri=IRI(pathlib.Path(path).as_uri())
         name=os.path.basename(path)
         hashes = file_hash(path)
         storage_size = file_storage_size(path)

--- a/bids2openminds/main.py
+++ b/bids2openminds/main.py
@@ -233,7 +233,7 @@ def create_file(layout_df, BIDS_path):
         path = file["path"]
         path_iri=pathlib.Path(path).as_uri()
         iri=IRI(path_iri)
-        name = path_iri[path_iri.rfind("/") + 1 :]
+        name=os.path.basename(path)
         hashes = file_hash(path)
         storage_size = file_storage_size(path)
         if pd.isna(file["subject"]):

--- a/bids2openminds/main.py
+++ b/bids2openminds/main.py
@@ -231,8 +231,9 @@ def create_file(layout_df, BIDS_path):
         data_types = None
         extension = file["extension"]
         path = file["path"]
-        name = path[path.rfind("/") + 1 :]
-        iri=IRI(pathlib.Path(path).as_uri())
+        path_iri=pathlib.Path(path).as_uri()
+        iri=IRI(path_iri)
+        name = path_iri[path_iri.rfind("/") + 1 :]
         hashes = file_hash(path)
         storage_size = file_storage_size(path)
         if pd.isna(file["subject"]):


### PR DESCRIPTION
The current way of handling the file name cause a problem for windows systems, so this pull request solves that. 