### PR TITLE
Use openMINDS version 3, rather than "latest"

### DIFF
--- a/bids2openminds/main.py
+++ b/bids2openminds/main.py
@@ -6,8 +6,8 @@ from warnings import warn
 import pandas as pd
 from nameparser import HumanName
 
-import openminds.latest.core as omcore
-import openminds.latest.controlled_terms as controlled_terms
+import openminds.v3.core as omcore
+import openminds.v3.controlled_terms as controlled_terms
 from openminds import IRI
 
 from .utility import table_filter, pd_table_value, file_hash, file_storage_size, detect_nifti_version

--- a/bids2openminds/report.py
+++ b/bids2openminds/report.py
@@ -9,20 +9,20 @@ def create_report(dataset, dataset_version, collection, dataset_description, inp
     behavioral_protocols_numbers = 0
 
     for item in collection:
-        if item.type_ == "https://openminds.ebrains.eu/core/Subject":
+        if item.type_.endswith("Subject"):
 
             subject_number += 1
             subject_state_numbers.append(len(item.studied_states))
 
-        if item.type_ == "https://openminds.ebrains.eu/core/File":
+        if item.type_.endswith("File"):
 
             files_number += 1
 
-        if item.type_ == "https://openminds.ebrains.eu/core/FileBundle":
+        if item.type_.endswith("FileBundle"):
 
             file_bundle_number += 1
 
-        if item.type_ == "https://openminds.ebrains.eu/core/BehavioralProtocol":
+        if item.type_.endswith("BehavioralProtocol"):
 
             behavioral_protocols_numbers += 1
 

--- a/bids2openminds/utility.py
+++ b/bids2openminds/utility.py
@@ -7,9 +7,9 @@ from warnings import warn
 
 import pandas as pd
 
-import openminds.latest.controlled_terms as controlled_terms
-from openminds.latest.core import Hash, QuantitativeValue, ContentType
-from openminds.latest.controlled_terms import UnitOfMeasurement
+import openminds.v3.controlled_terms as controlled_terms
+from openminds.v3.core import Hash, QuantitativeValue, ContentType
+from openminds.v3.controlled_terms import UnitOfMeasurement
 
 
 def read_json(file_path: str) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bids2openminds"
-version = "0.1.0"
+version = "0.1.1.dev.0"
 dependencies = [
   "bids",
   "openminds >= 0.2.3",

--- a/test/test_person.py
+++ b/test/test_person.py
@@ -1,7 +1,7 @@
 # test for create_openminds_person function in the main
 import pytest
 from bids2openminds.main import create_openminds_person
-import openminds.latest.core as omcore
+import openminds.v3.core as omcore
 
 # Test data: (full_name, given_name, family_name)
 example_names = [("John Ronald Reuel Tolkien", "John Ronald Reuel", "Tolkien"),


### PR DESCRIPTION
This fixes the failing tests.

I think we should make a v0.1.1 release with openMINDS pinned to v3, then start preparing a v0.2 release that would allow the user to specify the version (with v4 as the default).