### PR TITLE
codespell: move configuration into pyproject.toml, add workflow annotation action

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,3 +1,4 @@
+# Codespell configuration is within pyproject.toml
 ---
 name: Codespell
 
@@ -18,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
       - name: Codespell
         uses: codespell-project/actions-codespell@v2
-        with:
-          skip: light_openMINDS-bids2openminds-logo.svg, dark_openMINDS-bids2openminds-logo.svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,10 @@ line-length = 119
 
 [tool.setuptools]
 packages = ["bids2openminds"]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''


### PR DESCRIPTION
Just a few tune ups I spotted due.

Also moved skiping .svg into config instead of workflow