### PR TITLE
Use openMINDS v4 instead of v3

### DIFF
--- a/bids2openminds/main.py
+++ b/bids2openminds/main.py
@@ -6,8 +6,8 @@ from warnings import warn
 import pandas as pd
 from nameparser import HumanName
 
-import openminds.v3.core as omcore
-import openminds.v3.controlled_terms as controlled_terms
+import openminds.v4.core as omcore
+import openminds.v4.controlled_terms as controlled_terms
 from openminds import IRI
 
 from .utility import table_filter, pd_table_value, file_hash, file_storage_size, detect_nifti_version

--- a/bids2openminds/utility.py
+++ b/bids2openminds/utility.py
@@ -7,9 +7,9 @@ from warnings import warn
 
 import pandas as pd
 
-import openminds.v3.controlled_terms as controlled_terms
-from openminds.v3.core import Hash, QuantitativeValue, ContentType
-from openminds.v3.controlled_terms import UnitOfMeasurement
+import openminds.v4.controlled_terms as controlled_terms
+from openminds.v4.core import Hash, QuantitativeValue, ContentType
+from openminds.v4.controlled_terms import UnitOfMeasurement
 
 
 def read_json(file_path: str) -> dict:

--- a/test/bids_examples_ds005.jsonld
+++ b/test/bids_examples_ds005.jsonld
@@ -1,15 +1,15 @@
 {
   "@context": {
-    "@vocab": "https://openminds.ebrains.eu/vocab/"
+    "@vocab": "https://openminds.om-i.org/props/"
   },
   "@graph": [
     {
       "@id": "_:000000",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 28
       },
@@ -17,20 +17,15 @@
       "lookupLabel": "Studied state sub-01"
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/UnitOfMeasurement",
-      "name": "year"
-    },
-    {
       "@id": "_:000002",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-01",
       "lookupLabel": "sub-01",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -39,35 +34,12 @@
       ]
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/BiologicalSex",
-      "definition": "Biological sex that produces sperm cells (spermatozoa).",
-      "description": "A male organism typically has the capacity to produce relatively small, usually mobile gametes (reproductive cells), called sperm cells (or spermatozoa). In the process of fertilization, these sperm cells fuse with a larger, usually immobile female gamete, called egg cell (or ovum).",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106489",
-      "name": "male",
-      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/PATO_0000384"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/Species",
-      "definition": "The species *Homo sapiens* (humans) belongs to the family of *hominidae* (great apes).",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105114",
-      "knowledgeSpaceLink": "https://knowledge-space.org/wiki/NCBITaxon:9606#human",
-      "name": "Homo sapiens",
-      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
-      "synonym": [
-        "homo sapien",
-        "human",
-        "man"
-      ]
-    },
-    {
       "@id": "_:000005",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 21
       },
@@ -76,14 +48,14 @@
     },
     {
       "@id": "_:000006",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-02",
       "lookupLabel": "sub-02",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -92,21 +64,12 @@
       ]
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/BiologicalSex",
-      "definition": "Biological sex that produces egg cells (ova).",
-      "description": "A female organism typically has the capacity to produce relatively large, usually immobile gametes (reproductive cells), called egg cells (or ova). In the process of fertilization, an egg cell (ovum) fuses with a smaller, usually mobile male gametes, called sperm cells (or spermatozoa).",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104150",
-      "name": "female",
-      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/PATO_0000383"
-    },
-    {
       "@id": "_:000008",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 27
       },
@@ -115,14 +78,14 @@
     },
     {
       "@id": "_:000009",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-03",
       "lookupLabel": "sub-03",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -132,11 +95,11 @@
     },
     {
       "@id": "_:000010",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 25
       },
@@ -145,14 +108,14 @@
     },
     {
       "@id": "_:000011",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-04",
       "lookupLabel": "sub-04",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -162,11 +125,11 @@
     },
     {
       "@id": "_:000012",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 20
       },
@@ -175,14 +138,14 @@
     },
     {
       "@id": "_:000013",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-05",
       "lookupLabel": "sub-05",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -192,11 +155,11 @@
     },
     {
       "@id": "_:000014",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 20
       },
@@ -205,14 +168,14 @@
     },
     {
       "@id": "_:000015",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-06",
       "lookupLabel": "sub-06",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -222,11 +185,11 @@
     },
     {
       "@id": "_:000016",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 24
       },
@@ -235,14 +198,14 @@
     },
     {
       "@id": "_:000017",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-07",
       "lookupLabel": "sub-07",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -252,11 +215,11 @@
     },
     {
       "@id": "_:000018",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 25
       },
@@ -265,14 +228,14 @@
     },
     {
       "@id": "_:000019",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-08",
       "lookupLabel": "sub-08",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -282,11 +245,11 @@
     },
     {
       "@id": "_:000020",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 19
       },
@@ -295,14 +258,14 @@
     },
     {
       "@id": "_:000021",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-09",
       "lookupLabel": "sub-09",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -312,11 +275,11 @@
     },
     {
       "@id": "_:000022",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 20
       },
@@ -325,14 +288,14 @@
     },
     {
       "@id": "_:000023",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-10",
       "lookupLabel": "sub-10",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -342,11 +305,11 @@
     },
     {
       "@id": "_:000024",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 20
       },
@@ -355,14 +318,14 @@
     },
     {
       "@id": "_:000025",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-11",
       "lookupLabel": "sub-11",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -372,11 +335,11 @@
     },
     {
       "@id": "_:000026",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 21
       },
@@ -385,14 +348,14 @@
     },
     {
       "@id": "_:000027",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-12",
       "lookupLabel": "sub-12",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -402,11 +365,11 @@
     },
     {
       "@id": "_:000028",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 22
       },
@@ -415,14 +378,14 @@
     },
     {
       "@id": "_:000029",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-13",
       "lookupLabel": "sub-13",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -432,11 +395,11 @@
     },
     {
       "@id": "_:000030",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 19
       },
@@ -445,14 +408,14 @@
     },
     {
       "@id": "_:000031",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-14",
       "lookupLabel": "sub-14",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -462,11 +425,11 @@
     },
     {
       "@id": "_:000032",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 20
       },
@@ -475,14 +438,14 @@
     },
     {
       "@id": "_:000033",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/female"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/female"
       },
       "internalIdentifier": "sub-15",
       "lookupLabel": "sub-15",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -492,11 +455,11 @@
     },
     {
       "@id": "_:000034",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "age": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/year"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year"
         },
         "value": 22
       },
@@ -505,14 +468,14 @@
     },
     {
       "@id": "_:000035",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "biologicalSex": {
-        "@id": "https://openminds.ebrains.eu/instances/biologicalSex/male"
+        "@id": "https://openminds.om-i.org/instances/biologicalSex/male"
       },
       "internalIdentifier": "sub-16",
       "lookupLabel": "sub-16",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -522,900 +485,880 @@
     },
     {
       "@id": "_:000036",
-      "@type": "https://openminds.ebrains.eu/core/BehavioralProtocol",
+      "@type": "https://openminds.om-i.org/types/BehavioralProtocol",
       "description": "To be defined",
       "internalIdentifier": "mixedgamblestask",
       "name": "mixedgamblestask"
     },
     {
       "@id": "_:000037",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-12/anat",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-13/anat",
       "isPartOf": {
         "@id": "_:000038"
       },
-      "name": "sub-12/anat",
+      "name": "sub-13/anat",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000038",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-12",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-12",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17522
-      }
-    },
-    {
-      "@id": "_:000039",
-      "@type": "https://openminds.ebrains.eu/core/FileRepository",
-      "IRI": "file:///home/peyman-user/Desktop/data/bids_test/bids-examples/ds005",
-      "format": {
-        "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.bids"
-      },
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 283242
-      }
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.bids",
-      "@type": "https://openminds.ebrains.eu/core/ContentType",
-      "name": "application/vnd.bids",
-      "synonym": [
-        "BIDS"
-      ]
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/UnitOfMeasurement",
-      "name": "byte"
-    },
-    {
-      "@id": "_:000042",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-12/func",
-      "isPartOf": {
-        "@id": "_:000038"
-      },
-      "name": "sub-12/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17522
-      }
-    },
-    {
-      "@id": "_:000043",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-05/anat",
-      "isPartOf": {
-        "@id": "_:000044"
-      },
-      "name": "sub-05/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000044",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-05",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-05",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17626
-      }
-    },
-    {
-      "@id": "_:000045",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-05/func",
-      "isPartOf": {
-        "@id": "_:000044"
-      },
-      "name": "sub-05/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17626
-      }
-    },
-    {
-      "@id": "_:000046",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-16/anat",
-      "isPartOf": {
-        "@id": "_:000047"
-      },
-      "name": "sub-16/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000047",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-16",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-16",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17482
-      }
-    },
-    {
-      "@id": "_:000048",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-16/func",
-      "isPartOf": {
-        "@id": "_:000047"
-      },
-      "name": "sub-16/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17482
-      }
-    },
-    {
-      "@id": "_:000049",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-06/anat",
-      "isPartOf": {
-        "@id": "_:000050"
-      },
-      "name": "sub-06/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000050",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-06",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-06",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17465
-      }
-    },
-    {
-      "@id": "_:000051",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-06/func",
-      "isPartOf": {
-        "@id": "_:000050"
-      },
-      "name": "sub-06/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17465
-      }
-    },
-    {
-      "@id": "_:000052",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-11/anat",
-      "isPartOf": {
-        "@id": "_:000053"
-      },
-      "name": "sub-11/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000053",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-11",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-11",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17456
-      }
-    },
-    {
-      "@id": "_:000054",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-11/func",
-      "isPartOf": {
-        "@id": "_:000053"
-      },
-      "name": "sub-11/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17456
-      }
-    },
-    {
-      "@id": "_:000055",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-01/anat",
-      "isPartOf": {
-        "@id": "_:000056"
-      },
-      "name": "sub-01/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000056",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-01",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-01",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17453
-      }
-    },
-    {
-      "@id": "_:000057",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-01/func",
-      "isPartOf": {
-        "@id": "_:000056"
-      },
-      "name": "sub-01/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17453
-      }
-    },
-    {
-      "@id": "_:000058",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-09/anat",
-      "isPartOf": {
-        "@id": "_:000059"
-      },
-      "name": "sub-09/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000059",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-09",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-09",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17560
-      }
-    },
-    {
-      "@id": "_:000060",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-09/func",
-      "isPartOf": {
-        "@id": "_:000059"
-      },
-      "name": "sub-09/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17560
-      }
-    },
-    {
-      "@id": "_:000061",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-02/anat",
-      "isPartOf": {
-        "@id": "_:000062"
-      },
-      "name": "sub-02/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000062",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-02",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-02",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17674
-      }
-    },
-    {
-      "@id": "_:000063",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-02/func",
-      "isPartOf": {
-        "@id": "_:000062"
-      },
-      "name": "sub-02/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17674
-      }
-    },
-    {
-      "@id": "_:000064",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-14/anat",
-      "isPartOf": {
-        "@id": "_:000065"
-      },
-      "name": "sub-14/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000065",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-14",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-14",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17600
-      }
-    },
-    {
-      "@id": "_:000066",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-14/func",
-      "isPartOf": {
-        "@id": "_:000065"
-      },
-      "name": "sub-14/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17600
-      }
-    },
-    {
-      "@id": "_:000067",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-04/anat",
-      "isPartOf": {
-        "@id": "_:000068"
-      },
-      "name": "sub-04/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000068",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-04",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-04",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17613
-      }
-    },
-    {
-      "@id": "_:000069",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-04/func",
-      "isPartOf": {
-        "@id": "_:000068"
-      },
-      "name": "sub-04/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17613
-      }
-    },
-    {
-      "@id": "_:000070",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-10/anat",
-      "isPartOf": {
-        "@id": "_:000071"
-      },
-      "name": "sub-10/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000071",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-10",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-10",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17455
-      }
-    },
-    {
-      "@id": "_:000072",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-10/func",
-      "isPartOf": {
-        "@id": "_:000071"
-      },
-      "name": "sub-10/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17455
-      }
-    },
-    {
-      "@id": "_:000073",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-07/anat",
-      "isPartOf": {
-        "@id": "_:000074"
-      },
-      "name": "sub-07/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000074",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-07",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-07",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17483
-      }
-    },
-    {
-      "@id": "_:000075",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-07/func",
-      "isPartOf": {
-        "@id": "_:000074"
-      },
-      "name": "sub-07/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17483
-      }
-    },
-    {
-      "@id": "_:000076",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-13/anat",
-      "isPartOf": {
-        "@id": "_:000077"
-      },
-      "name": "sub-13/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000077",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
       "contentDescription": "File bundle created for sub-13",
       "isPartOf": {
         "@id": "_:000039"
       },
       "name": "sub-13",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 17512
       }
     },
     {
-      "@id": "_:000078",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
+      "@id": "_:000039",
+      "@type": "https://openminds.om-i.org/types/FileRepository",
+      "IRI": "file:///Users/adavison/dev/data/bids2openminds/bids-examples/ds005",
+      "format": {
+        "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.bids"
+      },
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 283242
+      }
+    },
+    {
+      "@id": "_:000042",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
       "contentDescription": "File bundle created for sub-13/func",
       "isPartOf": {
-        "@id": "_:000077"
+        "@id": "_:000038"
       },
       "name": "sub-13/func",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 17512
       }
     },
     {
-      "@id": "_:000079",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-08/anat",
+      "@id": "_:000043",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-14/anat",
       "isPartOf": {
-        "@id": "_:000080"
+        "@id": "_:000044"
       },
-      "name": "sub-08/anat",
+      "name": "sub-14/anat",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
-      "@id": "_:000080",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-08",
+      "@id": "_:000044",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-14",
       "isPartOf": {
         "@id": "_:000039"
       },
-      "name": "sub-08",
+      "name": "sub-14",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 17459
+        "value": 17600
       }
     },
     {
-      "@id": "_:000081",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-08/func",
+      "@id": "_:000045",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-14/func",
       "isPartOf": {
-        "@id": "_:000080"
+        "@id": "_:000044"
       },
-      "name": "sub-08/func",
+      "name": "sub-14/func",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 17459
+        "value": 17600
       }
     },
     {
-      "@id": "_:000082",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-03/anat",
-      "isPartOf": {
-        "@id": "_:000083"
-      },
-      "name": "sub-03/anat",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000083",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-03",
-      "isPartOf": {
-        "@id": "_:000039"
-      },
-      "name": "sub-03",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17795
-      }
-    },
-    {
-      "@id": "_:000084",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-03/func",
-      "isPartOf": {
-        "@id": "_:000083"
-      },
-      "name": "sub-03/func",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 17795
-      }
-    },
-    {
-      "@id": "_:000085",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
+      "@id": "_:000046",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
       "contentDescription": "File bundle created for sub-15/anat",
       "isPartOf": {
-        "@id": "_:000086"
+        "@id": "_:000047"
       },
       "name": "sub-15/anat",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
-      "@id": "_:000086",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
+      "@id": "_:000047",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
       "contentDescription": "File bundle created for sub-15",
       "isPartOf": {
         "@id": "_:000039"
       },
       "name": "sub-15",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 17520
+      }
+    },
+    {
+      "@id": "_:000048",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-15/func",
+      "isPartOf": {
+        "@id": "_:000047"
+      },
+      "name": "sub-15/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17520
+      }
+    },
+    {
+      "@id": "_:000049",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-12/anat",
+      "isPartOf": {
+        "@id": "_:000050"
+      },
+      "name": "sub-12/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000050",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-12",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-12",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17522
+      }
+    },
+    {
+      "@id": "_:000051",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-12/func",
+      "isPartOf": {
+        "@id": "_:000050"
+      },
+      "name": "sub-12/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17522
+      }
+    },
+    {
+      "@id": "_:000052",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-08/anat",
+      "isPartOf": {
+        "@id": "_:000053"
+      },
+      "name": "sub-08/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000053",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-08",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-08",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17459
+      }
+    },
+    {
+      "@id": "_:000054",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-08/func",
+      "isPartOf": {
+        "@id": "_:000053"
+      },
+      "name": "sub-08/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17459
+      }
+    },
+    {
+      "@id": "_:000055",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-01/anat",
+      "isPartOf": {
+        "@id": "_:000056"
+      },
+      "name": "sub-01/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000056",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-01",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-01",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17453
+      }
+    },
+    {
+      "@id": "_:000057",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-01/func",
+      "isPartOf": {
+        "@id": "_:000056"
+      },
+      "name": "sub-01/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17453
+      }
+    },
+    {
+      "@id": "_:000058",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-06/anat",
+      "isPartOf": {
+        "@id": "_:000059"
+      },
+      "name": "sub-06/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000059",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-06",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-06",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17465
+      }
+    },
+    {
+      "@id": "_:000060",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-06/func",
+      "isPartOf": {
+        "@id": "_:000059"
+      },
+      "name": "sub-06/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17465
+      }
+    },
+    {
+      "@id": "_:000061",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-07/anat",
+      "isPartOf": {
+        "@id": "_:000062"
+      },
+      "name": "sub-07/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000062",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-07",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-07",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17483
+      }
+    },
+    {
+      "@id": "_:000063",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-07/func",
+      "isPartOf": {
+        "@id": "_:000062"
+      },
+      "name": "sub-07/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17483
+      }
+    },
+    {
+      "@id": "_:000064",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-09/anat",
+      "isPartOf": {
+        "@id": "_:000065"
+      },
+      "name": "sub-09/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000065",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-09",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-09",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17560
+      }
+    },
+    {
+      "@id": "_:000066",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-09/func",
+      "isPartOf": {
+        "@id": "_:000065"
+      },
+      "name": "sub-09/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17560
+      }
+    },
+    {
+      "@id": "_:000067",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-10/anat",
+      "isPartOf": {
+        "@id": "_:000068"
+      },
+      "name": "sub-10/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000068",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-10",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-10",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17455
+      }
+    },
+    {
+      "@id": "_:000069",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-10/func",
+      "isPartOf": {
+        "@id": "_:000068"
+      },
+      "name": "sub-10/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17455
+      }
+    },
+    {
+      "@id": "_:000070",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-11/anat",
+      "isPartOf": {
+        "@id": "_:000071"
+      },
+      "name": "sub-11/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000071",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-11",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-11",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17456
+      }
+    },
+    {
+      "@id": "_:000072",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-11/func",
+      "isPartOf": {
+        "@id": "_:000071"
+      },
+      "name": "sub-11/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17456
+      }
+    },
+    {
+      "@id": "_:000073",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-16/anat",
+      "isPartOf": {
+        "@id": "_:000074"
+      },
+      "name": "sub-16/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000074",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-16",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-16",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17482
+      }
+    },
+    {
+      "@id": "_:000075",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-16/func",
+      "isPartOf": {
+        "@id": "_:000074"
+      },
+      "name": "sub-16/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17482
+      }
+    },
+    {
+      "@id": "_:000076",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-05/anat",
+      "isPartOf": {
+        "@id": "_:000077"
+      },
+      "name": "sub-05/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000077",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-05",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-05",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17626
+      }
+    },
+    {
+      "@id": "_:000078",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-05/func",
+      "isPartOf": {
+        "@id": "_:000077"
+      },
+      "name": "sub-05/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17626
+      }
+    },
+    {
+      "@id": "_:000079",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-02/anat",
+      "isPartOf": {
+        "@id": "_:000080"
+      },
+      "name": "sub-02/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000080",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-02",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-02",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17674
+      }
+    },
+    {
+      "@id": "_:000081",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-02/func",
+      "isPartOf": {
+        "@id": "_:000080"
+      },
+      "name": "sub-02/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17674
+      }
+    },
+    {
+      "@id": "_:000082",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-03/anat",
+      "isPartOf": {
+        "@id": "_:000083"
+      },
+      "name": "sub-03/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000083",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-03",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-03",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17795
+      }
+    },
+    {
+      "@id": "_:000084",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-03/func",
+      "isPartOf": {
+        "@id": "_:000083"
+      },
+      "name": "sub-03/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17795
+      }
+    },
+    {
+      "@id": "_:000085",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-04/anat",
+      "isPartOf": {
+        "@id": "_:000086"
+      },
+      "name": "sub-04/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000086",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-04",
+      "isPartOf": {
+        "@id": "_:000039"
+      },
+      "name": "sub-04",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 17613
       }
     },
     {
       "@id": "_:000087",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-15/func",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-04/func",
       "isPartOf": {
         "@id": "_:000086"
       },
-      "name": "sub-15/func",
+      "name": "sub-04/func",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 17520
+        "value": 17613
       }
     },
     {
       "@id": "_:000088",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXdataset_description.json",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "4ebe50046df891942c2fcf96226900ea"
         }
       ],
       "name": "dataset_description.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 870
       }
     },
     {
       "@id": "_:000089",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXparticipants.json",
       "contentDescription": "A JSON metadata file of participants TSV.",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/associativeArray"
+          "@id": "https://openminds.om-i.org/instances/dataType/associativeArray"
         }
       ],
       "fileRepository": {
         "@id": "_:000039"
       },
       "format": {
-        "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_json"
+        "@id": "https://openminds.om-i.org/instances/contentTypes/application_json"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "4e2cb474efdb8f7130a2f358bd7c785c"
         }
       ],
       "name": "participants.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 247
       }
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/dataType/associativeArray",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/DataType",
-      "definition": "A 'associative array' is an abstract data type that associates keys (scalars) with values (scalars, lists or matrices).",
-      "name": "associative array",
-      "preferredOntologyIdentifier": "https://www.wikidata.org/wiki/Q80585",
-      "synonym": [
-        "dictionary"
-      ]
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_json",
-      "@type": "https://openminds.ebrains.eu/core/ContentType",
-      "fileExtension": [
-        ".json"
-      ],
-      "name": "application/json",
-      "relatedMediaType": "https://www.iana.org/assignments/media-types/application/json",
-      "synonym": [
-        "JavaScript Object Notation",
-        "JSON"
-      ]
-    },
-    {
       "@id": "_:000092",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXparticipants.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "9fd64873ed187abea73f9d287cb64ef2"
         }
       ],
       "name": "participants.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 215
       }
     },
     {
       "@id": "_:000093",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/anat/sub-01_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 01",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1423,7 +1366,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1435,26 +1378,21 @@
       ],
       "name": "sub-01_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/DataType",
-      "definition": "'Voxel data' is a matrix defining values (scalars, lists, or matrices) on a grid in a three dimensional space, which can be rendered to raster graphic.",
-      "name": "voxel data"
-    },
-    {
       "@id": "_:000095",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/anat/sub-01_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 01",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1462,7 +1400,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1474,20 +1412,21 @@
       ],
       "name": "sub-01_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000096",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 01",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1495,7 +1434,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1507,22 +1446,23 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000097",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "e4329e63117fa7b8ec4102924db2f5bb"
         }
@@ -1534,21 +1474,21 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5866
       }
     },
     {
       "@id": "_:000098",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 01",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1556,7 +1496,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1568,22 +1508,23 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000099",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "9c23df9dd9e34a8f21ff07702064ee04"
         }
@@ -1595,21 +1536,21 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5787
       }
     },
     {
       "@id": "_:000100",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 01",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1617,7 +1558,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1629,22 +1570,23 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000101",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-01/func/sub-01_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "4aa5c4c55578d1dac672d84979466c32"
         }
@@ -1656,21 +1598,21 @@
       ],
       "name": "sub-01_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5800
       }
     },
     {
       "@id": "_:000102",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/anat/sub-02_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 02",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1678,32 +1620,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000061"
+          "@id": "_:000079"
         }
       ],
       "name": "sub-02_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000103",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/anat/sub-02_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 02",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1711,32 +1654,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000061"
+          "@id": "_:000079"
         }
       ],
       "name": "sub-02_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000104",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 02",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1744,60 +1688,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000105",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8a33d83d9dd56e9b632f40ef0151b511"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5932
       }
     },
     {
       "@id": "_:000106",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 02",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1805,60 +1750,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000107",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8c229862cf6dbefbcbe4ce770aaec204"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5865
       }
     },
     {
       "@id": "_:000108",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 02",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1866,60 +1812,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000109",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-02/func/sub-02_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8391f4066535dccdd759a7ca36be1bf6"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000063"
+          "@id": "_:000081"
         }
       ],
       "name": "sub-02_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5877
       }
     },
     {
       "@id": "_:000110",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/anat/sub-03_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 03",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1927,7 +1874,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1939,20 +1886,21 @@
       ],
       "name": "sub-03_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000111",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/anat/sub-03_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 03",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1960,7 +1908,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -1972,20 +1920,21 @@
       ],
       "name": "sub-03_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000112",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 03",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -1993,7 +1942,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -2005,22 +1954,23 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000113",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "b2b0df0843a17f3e570a78c6bca5bbda"
         }
@@ -2032,21 +1982,21 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5972
       }
     },
     {
       "@id": "_:000114",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 03",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2054,7 +2004,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -2066,22 +2016,23 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000115",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "2e99bb12741c9c46d93e451f0c9b7e8c"
         }
@@ -2093,21 +2044,21 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5906
       }
     },
     {
       "@id": "_:000116",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 03",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2115,7 +2066,7 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -2127,22 +2078,23 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000117",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-03/func/sub-03_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "eca34745537bde2ad2e1e67bd4ab3478"
         }
@@ -2154,21 +2106,21 @@
       ],
       "name": "sub-03_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5917
       }
     },
     {
       "@id": "_:000118",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/anat/sub-04_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 04",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2176,32 +2128,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000067"
+          "@id": "_:000085"
         }
       ],
       "name": "sub-04_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000119",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/anat/sub-04_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 04",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2209,32 +2162,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000067"
+          "@id": "_:000085"
         }
       ],
       "name": "sub-04_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000120",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 04",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2242,60 +2196,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000069"
+          "@id": "_:000087"
         }
       ],
       "name": "sub-04_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000121",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "c21b2f88c0ea4a771904ea81d0ca496c"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000069"
+          "@id": "_:000087"
         }
       ],
       "name": "sub-04_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5917
       }
     },
     {
       "@id": "_:000122",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 04",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2303,60 +2258,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000069"
+          "@id": "_:000087"
         }
       ],
       "name": "sub-04_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000123",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "bad676cfa37c8d8ded931c1110c875b2"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000069"
+          "@id": "_:000087"
         }
       ],
       "name": "sub-04_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5845
       }
     },
     {
       "@id": "_:000124",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 04",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -2364,36 +2320,1409 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000069"
+          "@id": "_:000087"
         }
       ],
       "name": "sub-04_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000125",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-04/func/sub-04_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "60278f7834717168acff781bba68c908"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000087"
+        }
+      ],
+      "name": "sub-04_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5851
+      }
+    },
+    {
+      "@id": "_:000126",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/anat/sub-05_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 05",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000076"
+        }
+      ],
+      "name": "sub-05_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000127",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/anat/sub-05_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 05",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000076"
+        }
+      ],
+      "name": "sub-05_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000128",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 05",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-01_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000129",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-01_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "38ad4cb48ea7d50b4727b01a4055727c"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-01_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5958
+      }
+    },
+    {
+      "@id": "_:000130",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-02_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 05",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-02_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000131",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-02_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "94c676883baa33d9ffd14d1cd5dd3923"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-02_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5832
+      }
+    },
+    {
+      "@id": "_:000132",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-03_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 05",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-03_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000133",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-03_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "cd9f21b2165118a8c881044d1f929fd8"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000078"
+        }
+      ],
+      "name": "sub-05_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5836
+      }
+    },
+    {
+      "@id": "_:000134",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/anat/sub-06_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 06",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000058"
+        }
+      ],
+      "name": "sub-06_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000135",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/anat/sub-06_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 06",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000058"
+        }
+      ],
+      "name": "sub-06_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000136",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 06",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-01_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000137",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-01_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "1e185b7522b69d2b7e4084030f444292"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-01_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5862
+      }
+    },
+    {
+      "@id": "_:000138",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-02_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 06",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-02_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000139",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-02_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "56dfddd49c1b52ee555849b2076bb02b"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-02_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5790
+      }
+    },
+    {
+      "@id": "_:000140",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-03_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 06",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-03_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000141",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-03_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "1bb0809c0af6a42503ce9fc1078305c7"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000060"
+        }
+      ],
+      "name": "sub-06_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5813
+      }
+    },
+    {
+      "@id": "_:000142",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/anat/sub-07_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 07",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000061"
+        }
+      ],
+      "name": "sub-07_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000143",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/anat/sub-07_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 07",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000061"
+        }
+      ],
+      "name": "sub-07_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000144",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 07",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-01_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000145",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-01_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "7ea48703a5cd48f1517f8cc7705e27d7"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-01_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5863
+      }
+    },
+    {
+      "@id": "_:000146",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-02_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 07",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-02_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000147",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-02_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "68150e4cac2fe710026f31f55359860a"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-02_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5794
+      }
+    },
+    {
+      "@id": "_:000148",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-03_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 07",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-03_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000149",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-03_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "4f0962b22b3bd54f3a43082fcd5ddc9a"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000063"
+        }
+      ],
+      "name": "sub-07_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5826
+      }
+    },
+    {
+      "@id": "_:000150",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/anat/sub-08_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 08",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000052"
+        }
+      ],
+      "name": "sub-08_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000151",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/anat/sub-08_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 08",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000052"
+        }
+      ],
+      "name": "sub-08_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000152",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 08",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-01_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000153",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-01_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "52aa5f0672ba9836374ab7bd00f69a18"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-01_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5863
+      }
+    },
+    {
+      "@id": "_:000154",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-02_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 08",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-02_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000155",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-02_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "63b2b01c03d0ea01372ee230d634c0da"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-02_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5793
+      }
+    },
+    {
+      "@id": "_:000156",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-03_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 08",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-03_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000157",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-03_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "6b2d36db698eeb10cac7e9ed913382a3"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000054"
+        }
+      ],
+      "name": "sub-08_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5803
+      }
+    },
+    {
+      "@id": "_:000158",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/anat/sub-09_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 09",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000064"
+        }
+      ],
+      "name": "sub-09_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000159",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/anat/sub-09_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 09",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000064"
+        }
+      ],
+      "name": "sub-09_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000160",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 09",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-01_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000161",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-01_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "a7873f84905cf1d624db0cd34bd16d49"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-01_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5896
+      }
+    },
+    {
+      "@id": "_:000162",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-02_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 09",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-02_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000163",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-02_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "30621b418607b116d93eaf0ed082efea"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-02_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5826
+      }
+    },
+    {
+      "@id": "_:000164",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-03_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 09",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-03_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000165",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-03_events.tsv",
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "f527ba7b781691555e058315e41386e0"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000066"
+        }
+      ],
+      "name": "sub-09_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5838
+      }
+    },
+    {
+      "@id": "_:000166",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-10/anat/sub-10_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 10",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000067"
+        }
+      ],
+      "name": "sub-10_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000167",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-10/anat/sub-10_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 10",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000067"
+        }
+      ],
+      "name": "sub-10_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000168",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 10",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
@@ -2401,1395 +3730,51 @@
           "@id": "_:000069"
         }
       ],
-      "name": "sub-04_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5851
-      }
-    },
-    {
-      "@id": "_:000126",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/anat/sub-05_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 05",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000043"
-        }
-      ],
-      "name": "sub-05_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000127",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/anat/sub-05_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 05",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000043"
-        }
-      ],
-      "name": "sub-05_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000128",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 05",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-01_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000129",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-01_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "38ad4cb48ea7d50b4727b01a4055727c"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-01_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5958
-      }
-    },
-    {
-      "@id": "_:000130",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-02_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 05",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-02_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000131",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-02_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "94c676883baa33d9ffd14d1cd5dd3923"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-02_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5832
-      }
-    },
-    {
-      "@id": "_:000132",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-03_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 05",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-03_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000133",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-05/func/sub-05_task-mixedgamblestask_run-03_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "cd9f21b2165118a8c881044d1f929fd8"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000045"
-        }
-      ],
-      "name": "sub-05_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5836
-      }
-    },
-    {
-      "@id": "_:000134",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/anat/sub-06_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 06",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000049"
-        }
-      ],
-      "name": "sub-06_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000135",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/anat/sub-06_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 06",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000049"
-        }
-      ],
-      "name": "sub-06_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000136",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 06",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-01_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000137",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-01_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "1e185b7522b69d2b7e4084030f444292"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-01_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5862
-      }
-    },
-    {
-      "@id": "_:000138",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-02_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 06",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-02_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000139",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-02_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "56dfddd49c1b52ee555849b2076bb02b"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-02_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5790
-      }
-    },
-    {
-      "@id": "_:000140",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-03_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 06",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-03_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000141",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-06/func/sub-06_task-mixedgamblestask_run-03_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "1bb0809c0af6a42503ce9fc1078305c7"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000051"
-        }
-      ],
-      "name": "sub-06_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5813
-      }
-    },
-    {
-      "@id": "_:000142",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/anat/sub-07_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 07",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000073"
-        }
-      ],
-      "name": "sub-07_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000143",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/anat/sub-07_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 07",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000073"
-        }
-      ],
-      "name": "sub-07_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000144",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 07",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-01_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000145",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-01_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "7ea48703a5cd48f1517f8cc7705e27d7"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-01_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5863
-      }
-    },
-    {
-      "@id": "_:000146",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-02_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 07",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-02_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000147",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-02_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "68150e4cac2fe710026f31f55359860a"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-02_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5794
-      }
-    },
-    {
-      "@id": "_:000148",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-03_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 07",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-03_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000149",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-07/func/sub-07_task-mixedgamblestask_run-03_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "4f0962b22b3bd54f3a43082fcd5ddc9a"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000075"
-        }
-      ],
-      "name": "sub-07_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5826
-      }
-    },
-    {
-      "@id": "_:000150",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/anat/sub-08_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 08",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000079"
-        }
-      ],
-      "name": "sub-08_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000151",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/anat/sub-08_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 08",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000079"
-        }
-      ],
-      "name": "sub-08_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000152",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 08",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-01_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000153",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-01_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "52aa5f0672ba9836374ab7bd00f69a18"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-01_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5863
-      }
-    },
-    {
-      "@id": "_:000154",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-02_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 08",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-02_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000155",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-02_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "63b2b01c03d0ea01372ee230d634c0da"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-02_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5793
-      }
-    },
-    {
-      "@id": "_:000156",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-03_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 08",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-03_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000157",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-08/func/sub-08_task-mixedgamblestask_run-03_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "6b2d36db698eeb10cac7e9ed913382a3"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000081"
-        }
-      ],
-      "name": "sub-08_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5803
-      }
-    },
-    {
-      "@id": "_:000158",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/anat/sub-09_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 09",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000058"
-        }
-      ],
-      "name": "sub-09_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000159",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/anat/sub-09_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 09",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000058"
-        }
-      ],
-      "name": "sub-09_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000160",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 09",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-01_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000161",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-01_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "a7873f84905cf1d624db0cd34bd16d49"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-01_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5896
-      }
-    },
-    {
-      "@id": "_:000162",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-02_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 09",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-02_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000163",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-02_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "30621b418607b116d93eaf0ed082efea"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-02_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5826
-      }
-    },
-    {
-      "@id": "_:000164",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-03_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 09",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-03_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000165",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-09/func/sub-09_task-mixedgamblestask_run-03_events.tsv",
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "f527ba7b781691555e058315e41386e0"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000060"
-        }
-      ],
-      "name": "sub-09_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5838
-      }
-    },
-    {
-      "@id": "_:000166",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-10/anat/sub-10_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 10",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000070"
-        }
-      ],
-      "name": "sub-10_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000167",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-10/anat/sub-10_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 10",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000070"
-        }
-      ],
-      "name": "sub-10_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000168",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 10",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000072"
-        }
-      ],
       "name": "sub-10_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000169",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "90f407403dfbc3ee1fbd1774f8c1eb26"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000072"
+          "@id": "_:000069"
         }
       ],
       "name": "sub-10_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5865
       }
     },
     {
       "@id": "_:000170",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 10",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -3797,60 +3782,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000072"
+          "@id": "_:000069"
         }
       ],
       "name": "sub-10_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000171",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "9f7f2f1a67580dea3092d05c568657e4"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000072"
+          "@id": "_:000069"
         }
       ],
       "name": "sub-10_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5788
       }
     },
     {
       "@id": "_:000172",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 10",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -3858,36 +3844,139 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000072"
+          "@id": "_:000069"
         }
       ],
       "name": "sub-10_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000173",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-10/func/sub-10_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "4712fcc82d441531872ed254cfc41833"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000069"
+        }
+      ],
+      "name": "sub-10_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5802
+      }
+    },
+    {
+      "@id": "_:000174",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-11/anat/sub-11_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 11",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000070"
+        }
+      ],
+      "name": "sub-11_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000175",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-11/anat/sub-11_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 11",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000070"
+        }
+      ],
+      "name": "sub-11_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000176",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 11",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
@@ -3895,150 +3984,51 @@
           "@id": "_:000072"
         }
       ],
-      "name": "sub-10_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5802
-      }
-    },
-    {
-      "@id": "_:000174",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-11/anat/sub-11_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 11",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000052"
-        }
-      ],
-      "name": "sub-11_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000175",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-11/anat/sub-11_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 11",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000052"
-        }
-      ],
-      "name": "sub-11_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000176",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 11",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000054"
-        }
-      ],
       "name": "sub-11_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000177",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "75e1783e8e56977de538bc03e789ff42"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000054"
+          "@id": "_:000072"
         }
       ],
       "name": "sub-11_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5863
       }
     },
     {
       "@id": "_:000178",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 11",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4046,60 +4036,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000054"
+          "@id": "_:000072"
         }
       ],
       "name": "sub-11_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000179",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "a9b31b9f0cb309d417e1c93c13306746"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000054"
+          "@id": "_:000072"
         }
       ],
       "name": "sub-11_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5789
       }
     },
     {
       "@id": "_:000180",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 11",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4107,60 +4098,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000054"
+          "@id": "_:000072"
         }
       ],
       "name": "sub-11_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000181",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-11/func/sub-11_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "cc5a88b80bedf6e98a0c671ea0f5088b"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000054"
+          "@id": "_:000072"
         }
       ],
       "name": "sub-11_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5804
       }
     },
     {
       "@id": "_:000182",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/anat/sub-12_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 12",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4168,32 +4160,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000037"
+          "@id": "_:000049"
         }
       ],
       "name": "sub-12_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000183",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/anat/sub-12_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 12",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4201,32 +4194,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000037"
+          "@id": "_:000049"
         }
       ],
       "name": "sub-12_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000184",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 12",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4234,60 +4228,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000042"
+          "@id": "_:000051"
         }
       ],
       "name": "sub-12_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000185",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "3e4c4d113cb4cfeff2af994c642af153"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000042"
+          "@id": "_:000051"
         }
       ],
       "name": "sub-12_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5881
       }
     },
     {
       "@id": "_:000186",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 12",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4295,60 +4290,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000042"
+          "@id": "_:000051"
         }
       ],
       "name": "sub-12_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000187",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "42cfc809ac9f09ad4a62063a4b6f0315"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000042"
+          "@id": "_:000051"
         }
       ],
       "name": "sub-12_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5820
       }
     },
     {
       "@id": "_:000188",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 12",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4356,36 +4352,139 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000042"
+          "@id": "_:000051"
         }
       ],
       "name": "sub-12_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000189",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-12/func/sub-12_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "7054bf0a456314a57ea84f5d6d6f86ae"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000051"
+        }
+      ],
+      "name": "sub-12_task-mixedgamblestask_run-03_events.tsv",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 5821
+      }
+    },
+    {
+      "@id": "_:000190",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-13/anat/sub-13_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 13",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000037"
+        }
+      ],
+      "name": "sub-13_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000191",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-13/anat/sub-13_inplaneT2.nii.gz",
+      "contentDescription": "Data file for inplaneT2 of subject 13",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000037"
+        }
+      ],
+      "name": "sub-13_inplaneT2.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000192",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-01_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 13",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000039"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
@@ -4393,150 +4492,51 @@
           "@id": "_:000042"
         }
       ],
-      "name": "sub-12_task-mixedgamblestask_run-03_events.tsv",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 5821
-      }
-    },
-    {
-      "@id": "_:000190",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-13/anat/sub-13_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 13",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000076"
-        }
-      ],
-      "name": "sub-13_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000191",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-13/anat/sub-13_inplaneT2.nii.gz",
-      "contentDescription": "Data file for inplaneT2 of subject 13",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000076"
-        }
-      ],
-      "name": "sub-13_inplaneT2.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000192",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-01_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 13",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000039"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000078"
-        }
-      ],
       "name": "sub-13_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000193",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d02f29c98928dc078be9de07909444df"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000078"
+          "@id": "_:000042"
         }
       ],
       "name": "sub-13_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5880
       }
     },
     {
       "@id": "_:000194",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 13",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4544,60 +4544,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000078"
+          "@id": "_:000042"
         }
       ],
       "name": "sub-13_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000195",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "cb4d3ec19010d4d0e5fc8098d5d3b9d4"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000078"
+          "@id": "_:000042"
         }
       ],
       "name": "sub-13_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5812
       }
     },
     {
       "@id": "_:000196",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 13",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4605,60 +4606,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000078"
+          "@id": "_:000042"
         }
       ],
       "name": "sub-13_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000197",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-13/func/sub-13_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "3ee80e431cfdf369199d1506f7c9056a"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000078"
+          "@id": "_:000042"
         }
       ],
       "name": "sub-13_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5820
       }
     },
     {
       "@id": "_:000198",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/anat/sub-14_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 14",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4666,32 +4668,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000064"
+          "@id": "_:000043"
         }
       ],
       "name": "sub-14_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000199",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/anat/sub-14_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 14",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4699,32 +4702,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000064"
+          "@id": "_:000043"
         }
       ],
       "name": "sub-14_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000200",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 14",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4732,60 +4736,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000201",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "df441f867f39388880122d1ab078c728"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5912
       }
     },
     {
       "@id": "_:000202",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 14",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4793,60 +4798,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000203",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "2dbc0a25fa09ada60870fcff1d886cce"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5841
       }
     },
     {
       "@id": "_:000204",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 14",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4854,60 +4860,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000205",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-14/func/sub-14_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "0cc1cf79c2013cb49e683c6fc9c32e2b"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000066"
+          "@id": "_:000045"
         }
       ],
       "name": "sub-14_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5847
       }
     },
     {
       "@id": "_:000206",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/anat/sub-15_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 15",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4915,32 +4922,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000085"
+          "@id": "_:000046"
         }
       ],
       "name": "sub-15_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000207",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/anat/sub-15_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 15",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4948,32 +4956,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000085"
+          "@id": "_:000046"
         }
       ],
       "name": "sub-15_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000208",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 15",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -4981,60 +4990,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000209",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "78f867b359a18a06fbe4ffe8c64a28d8"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5882
       }
     },
     {
       "@id": "_:000210",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 15",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5042,60 +5052,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000211",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "3f79113eb8adeddcf69d5578488528fa"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5813
       }
     },
     {
       "@id": "_:000212",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 15",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5103,60 +5114,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000213",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-15/func/sub-15_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "2dfd0ca3df92f5e1581e386773bd73f5"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000087"
+          "@id": "_:000048"
         }
       ],
       "name": "sub-15_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5825
       }
     },
     {
       "@id": "_:000214",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/anat/sub-16_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 16",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5164,32 +5176,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000046"
+          "@id": "_:000073"
         }
       ],
       "name": "sub-16_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000215",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/anat/sub-16_inplaneT2.nii.gz",
       "contentDescription": "Data file for inplaneT2 of subject 16",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5197,32 +5210,33 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000046"
+          "@id": "_:000073"
         }
       ],
       "name": "sub-16_inplaneT2.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000216",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-01_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 16",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5230,60 +5244,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-01_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000217",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-01_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "38ebb3d45bae793a5dc7bca5397d971b"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-01_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5871
       }
     },
     {
       "@id": "_:000218",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-02_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 16",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5291,60 +5306,61 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-02_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000219",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-02_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "91a43a203ce087e31a677e16d365e2bd"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-02_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5794
       }
     },
     {
       "@id": "_:000220",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-03_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 16",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
@@ -5352,148 +5368,149 @@
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-03_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000221",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-16/func/sub-16_task-mixedgamblestask_run-03_events.tsv",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "86a3e562c65c50c48a71d9a4562aa288"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000048"
+          "@id": "_:000075"
         }
       ],
       "name": "sub-16_task-mixedgamblestask_run-03_events.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 5817
       }
     },
     {
       "@id": "_:000222",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXtask-mixedgamblestask_bold.json",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8c89b909fbcb8494a69c53afdb2d25ae"
         }
       ],
       "name": "task-mixedgamblestask_bold.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 67
       }
     },
     {
       "@id": "_:000223",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXCHANGES",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "99877475c9b8921878db046c3d119fb2"
         }
       ],
       "name": "CHANGES",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 149
       }
     },
     {
       "@id": "_:000224",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXREADME",
       "fileRepository": {
         "@id": "_:000039"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "3f16631d3dec0049d0d03d626be289bc"
         }
       ],
       "name": "README",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 1019
       }
     },
     {
       "@id": "_:000225",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "S.M.",
       "givenName": "Tom"
     },
     {
       "@id": "_:000226",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "C.R.",
       "givenName": "Fox"
     },
     {
       "@id": "_:000227",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "C.",
       "givenName": "Trepel"
     },
     {
       "@id": "_:000228",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "R.A.",
       "givenName": "Poldrack"
     },
     {
       "@id": "_:000229",
-      "@type": "https://openminds.ebrains.eu/core/DatasetVersion",
+      "@type": "https://openminds.om-i.org/types/DatasetVersion",
       "author": [
         {
           "@id": "_:000225"
@@ -5515,15 +5532,15 @@
       ],
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/semanticDataType/rawData"
+          "@id": "https://openminds.om-i.org/instances/semanticDataType/rawData"
         }
       ],
       "experimentalApproach": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/anatomy"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/anatomy"
         },
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuroimaging"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuroimaging"
         }
       ],
       "fullName": "Mixed-gambles task",
@@ -5583,51 +5600,13 @@
       ],
       "technique": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/technique/T2PulseSequence"
+          "@id": "https://openminds.om-i.org/instances/technique/structuralMagneticResonanceImaging"
         }
       ]
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/semanticDataType/rawData",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/SemanticDataType",
-      "name": "raw data"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/anatomy",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on the bodily structure of living organisms.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
-      "name": "anatomy",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Anatomy",
-      "synonym": [
-        "anatomical approach"
-      ]
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuroimaging",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on the non-invasive direct or indirect imaging of the structure, function, or pharmacology of the nervous system.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
-      "name": "neuroimaging",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Neuroimaging"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/technique/T2PulseSequence",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/Technique",
-      "definition": "In magnetic resonance imaging, a 'T2 pulse sequence' is a contrasting technique that allows the magnetization of the specimen or object to decay (spin-spin relaxation) before measuring the magnetic resonance signal by changing the echo time. [adapted from [wikipedia](https://en.wikipedia.org/wiki/MRI_sequence)]",
-      "name": "T2 pulse sequence",
-      "synonym": [
-        "T2 weighted imaging",
-        "T2 weighted magnetic resonance imaging",
-        "T2 weighted MRI",
-        "T2w imaging",
-        "T2w magnetic resonance imaging",
-        "T2w MRI"
-      ]
-    },
-    {
       "@id": "_:000234",
-      "@type": "https://openminds.ebrains.eu/core/Dataset",
+      "@type": "https://openminds.om-i.org/types/Dataset",
       "author": [
         {
           "@id": "_:000225"
@@ -5649,6 +5628,121 @@
         }
       ],
       "shortName": "Mixed-gambles task"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/biologicalSex/female",
+      "@type": "https://openminds.om-i.org/types/BiologicalSex",
+      "definition": "Biological sex that produces egg cells (ova).",
+      "description": "A female organism typically has the capacity to produce relatively large, usually immobile gametes (reproductive cells), called egg cells (or ova). In the process of fertilization, an egg cell (ovum) fuses with a smaller, usually mobile male gametes, called sperm cells (or spermatozoa).",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0104150",
+      "name": "female",
+      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/PATO_0000383"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/biologicalSex/male",
+      "@type": "https://openminds.om-i.org/types/BiologicalSex",
+      "definition": "Biological sex that produces sperm cells (spermatozoa).",
+      "description": "A male organism typically has the capacity to produce relatively small, usually mobile gametes (reproductive cells), called sperm cells (or spermatozoa). In the process of fertilization, these sperm cells fuse with a larger, usually immobile female gamete, called egg cell (or ovum).",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0106489",
+      "name": "male",
+      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/PATO_0000384"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/contentTypes/application_json",
+      "@type": "https://openminds.om-i.org/types/ContentType",
+      "fileExtension": [
+        ".json"
+      ],
+      "name": "application/json",
+      "relatedMediaType": "https://www.iana.org/assignments/media-types/application/json",
+      "synonym": [
+        "JavaScript Object Notation",
+        "JSON"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.bids",
+      "@type": "https://openminds.om-i.org/types/ContentType",
+      "name": "application/vnd.bids",
+      "synonym": [
+        "BIDS"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/dataType/associativeArray",
+      "@type": "https://openminds.om-i.org/types/DataType",
+      "definition": "A 'associative array' is an abstract data type that associates keys (scalars) with values (scalars, lists or matrices).",
+      "name": "associative array",
+      "preferredOntologyIdentifier": "https://www.wikidata.org/entity/Q80585",
+      "synonym": [
+        "dictionary"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/dataType/voxelData",
+      "@type": "https://openminds.om-i.org/types/DataType",
+      "definition": "'Voxel data' is a matrix defining values (scalars, lists, or matrices) on a grid in a three dimensional space, which can be rendered to raster graphic.",
+      "name": "voxel data"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/anatomy",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on the bodily structure of living organisms.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
+      "name": "anatomy",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Anatomy",
+      "synonym": [
+        "anatomical approach"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuroimaging",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on the non-invasive direct or indirect imaging of the structure, function, or pharmacology of the nervous system.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
+      "name": "neuroimaging",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Neuroimaging"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/semanticDataType/rawData",
+      "@type": "https://openminds.om-i.org/types/SemanticDataType",
+      "name": "raw data"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/species/homoSapiens",
+      "@type": "https://openminds.om-i.org/types/Species",
+      "definition": "The species *Homo sapiens* (humans) belongs to the family of *hominidae* (great apes).",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105114",
+      "knowledgeSpaceLink": "https://knowledge-space.org/wiki/NCBITaxon:9606#human",
+      "name": "Homo sapiens",
+      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+      "synonym": [
+        "homo sapien",
+        "human",
+        "man"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/technique/structuralMagneticResonanceImaging",
+      "@type": "https://openminds.om-i.org/types/Technique",
+      "definition": "A magnetic resonance imaging technique that uses strong magnetic fields, magnetic field gradients, and radio waves to generate images with static information of the scanned body.",
+      "name": "structural magnetic resonance imaging",
+      "synonym": [
+        "sMRI",
+        "structural MRI",
+        "MRI",
+        "magnetic resonance imaging"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte",
+      "@type": "https://openminds.om-i.org/types/UnitOfMeasurement",
+      "name": "byte"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/year",
+      "@type": "https://openminds.om-i.org/types/UnitOfMeasurement",
+      "name": "year"
     }
   ]
 }

--- a/test/bids_examples_eeg_rest_fmri.jsonld
+++ b/test/bids_examples_eeg_rest_fmri.jsonld
@@ -1,21 +1,21 @@
 {
   "@context": {
-    "@vocab": "https://openminds.ebrains.eu/vocab/"
+    "@vocab": "https://openminds.om-i.org/props/"
   },
   "@graph": [
     {
       "@id": "_:000000",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "internalIdentifier": "Studied state sub-32",
       "lookupLabel": "Studied state sub-32"
     },
     {
       "@id": "_:000001",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "internalIdentifier": "sub-32",
       "lookupLabel": "sub-32",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -24,32 +24,18 @@
       ]
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/Species",
-      "definition": "The species *Homo sapiens* (humans) belongs to the family of *hominidae* (great apes).",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105114",
-      "knowledgeSpaceLink": "https://knowledge-space.org/wiki/NCBITaxon:9606#human",
-      "name": "Homo sapiens",
-      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
-      "synonym": [
-        "homo sapien",
-        "human",
-        "man"
-      ]
-    },
-    {
       "@id": "_:000003",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "internalIdentifier": "Studied state sub-35",
       "lookupLabel": "Studied state sub-35"
     },
     {
       "@id": "_:000004",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "internalIdentifier": "sub-35",
       "lookupLabel": "sub-35",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -59,17 +45,17 @@
     },
     {
       "@id": "_:000005",
-      "@type": "https://openminds.ebrains.eu/core/SubjectState",
+      "@type": "https://openminds.om-i.org/types/SubjectState",
       "internalIdentifier": "Studied state sub-36",
       "lookupLabel": "Studied state sub-36"
     },
     {
       "@id": "_:000006",
-      "@type": "https://openminds.ebrains.eu/core/Subject",
+      "@type": "https://openminds.om-i.org/types/Subject",
       "internalIdentifier": "sub-36",
       "lookupLabel": "sub-36",
       "species": {
-        "@id": "https://openminds.ebrains.eu/instances/species/homoSapiens"
+        "@id": "https://openminds.om-i.org/instances/species/homoSapiens"
       },
       "studiedState": [
         {
@@ -79,756 +65,1388 @@
     },
     {
       "@id": "_:000007",
-      "@type": "https://openminds.ebrains.eu/core/BehavioralProtocol",
+      "@type": "https://openminds.om-i.org/types/BehavioralProtocol",
       "description": "To be defined",
       "internalIdentifier": "rest",
       "name": "rest"
     },
     {
       "@id": "_:000008",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-36/anat",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-36/eeg",
       "isPartOf": {
         "@id": "_:000009"
       },
-      "name": "sub-36/anat",
+      "name": "derivatives/sub-36/eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 377833
       }
     },
     {
       "@id": "_:000009",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-36",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-36",
       "isPartOf": {
         "@id": "_:000010"
       },
-      "name": "sub-36",
+      "name": "derivatives/sub-36",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 26126
+        "value": 377833
       }
     },
     {
       "@id": "_:000010",
-      "@type": "https://openminds.ebrains.eu/core/FileRepository",
-      "IRI": "file:///home/peyman-user/Desktop/Code/bids-examples/eeg_rest_fmri",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives",
+      "isPartOf": {
+        "@id": "_:000011"
+      },
+      "name": "derivatives",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 1124703
+      }
+    },
+    {
+      "@id": "_:000011",
+      "@type": "https://openminds.om-i.org/types/FileRepository",
+      "IRI": "file:///Users/adavison/dev/data/bids2openminds/bids-examples/eeg_rest_fmri",
       "format": {
-        "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.bids"
+        "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.bids"
       },
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 1208812
       }
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/contentTypes/application_vnd.bids",
-      "@type": "https://openminds.ebrains.eu/core/ContentType",
-      "name": "application/vnd.bids",
-      "synonym": [
-        "BIDS"
-      ]
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/UnitOfMeasurement",
-      "name": "byte"
-    },
-    {
-      "@id": "_:000013",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-36/dwi",
-      "isPartOf": {
-        "@id": "_:000009"
-      },
-      "name": "sub-36/dwi",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 3354
-      }
-    },
-    {
       "@id": "_:000014",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-36/func",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-32/eeg",
       "isPartOf": {
-        "@id": "_:000009"
+        "@id": "_:000015"
       },
-      "name": "sub-36/func",
+      "name": "derivatives/sub-32/eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 371026
       }
     },
     {
       "@id": "_:000015",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-36/eeg",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-32",
       "isPartOf": {
-        "@id": "_:000009"
+        "@id": "_:000010"
       },
-      "name": "sub-36/eeg",
+      "name": "derivatives/sub-32",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 22772
+        "value": 371026
       }
     },
     {
       "@id": "_:000016",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-32/anat",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-35/eeg",
       "isPartOf": {
         "@id": "_:000017"
       },
-      "name": "sub-32/anat",
+      "name": "derivatives/sub-35/eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 375844
       }
     },
     {
       "@id": "_:000017",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-32",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for derivatives/sub-35",
       "isPartOf": {
         "@id": "_:000010"
       },
-      "name": "sub-32",
+      "name": "derivatives/sub-35",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 27421
+        "value": 375844
       }
     },
     {
       "@id": "_:000018",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-32/dwi",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-36/dwi",
       "isPartOf": {
-        "@id": "_:000017"
+        "@id": "_:000019"
       },
-      "name": "sub-32/dwi",
+      "name": "sub-36/dwi",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 3354
       }
     },
     {
       "@id": "_:000019",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-32/func",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-36",
       "isPartOf": {
-        "@id": "_:000017"
+        "@id": "_:000011"
       },
-      "name": "sub-32/func",
+      "name": "sub-36",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 26126
       }
     },
     {
       "@id": "_:000020",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-32/eeg",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-36/anat",
       "isPartOf": {
-        "@id": "_:000017"
+        "@id": "_:000019"
       },
-      "name": "sub-32/eeg",
+      "name": "sub-36/anat",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 24067
+        "value": 0
       }
     },
     {
       "@id": "_:000021",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-35/anat",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-36/eeg",
       "isPartOf": {
-        "@id": "_:000022"
+        "@id": "_:000019"
       },
-      "name": "sub-35/anat",
+      "name": "sub-36/eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 22772
       }
     },
     {
       "@id": "_:000022",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-35",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-36/func",
       "isPartOf": {
-        "@id": "_:000010"
+        "@id": "_:000019"
       },
-      "name": "sub-35",
+      "name": "sub-36/func",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 27286
+        "value": 0
       }
     },
     {
       "@id": "_:000023",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-35/dwi",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-32/dwi",
       "isPartOf": {
-        "@id": "_:000022"
+        "@id": "_:000024"
       },
-      "name": "sub-35/dwi",
+      "name": "sub-32/dwi",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 3354
       }
     },
     {
       "@id": "_:000024",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for sub-35/func",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-32",
       "isPartOf": {
-        "@id": "_:000022"
+        "@id": "_:000011"
       },
-      "name": "sub-35/func",
+      "name": "sub-32",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 27421
       }
     },
     {
       "@id": "_:000025",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-32/anat",
+      "isPartOf": {
+        "@id": "_:000024"
+      },
+      "name": "sub-32/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000026",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-32/eeg",
+      "isPartOf": {
+        "@id": "_:000024"
+      },
+      "name": "sub-32/eeg",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 24067
+      }
+    },
+    {
+      "@id": "_:000027",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-32/func",
+      "isPartOf": {
+        "@id": "_:000024"
+      },
+      "name": "sub-32/func",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000028",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-35/dwi",
+      "isPartOf": {
+        "@id": "_:000029"
+      },
+      "name": "sub-35/dwi",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 3354
+      }
+    },
+    {
+      "@id": "_:000029",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-35",
+      "isPartOf": {
+        "@id": "_:000011"
+      },
+      "name": "sub-35",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 27286
+      }
+    },
+    {
+      "@id": "_:000030",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-35/anat",
+      "isPartOf": {
+        "@id": "_:000029"
+      },
+      "name": "sub-35/anat",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000031",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
       "contentDescription": "File bundle created for sub-35/eeg",
       "isPartOf": {
-        "@id": "_:000022"
+        "@id": "_:000029"
       },
       "name": "sub-35/eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 23932
       }
     },
     {
-      "@id": "_:000026",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-36/eeg",
-      "isPartOf": {
-        "@id": "_:000027"
-      },
-      "name": "derivatives/sub-36/eeg",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 377833
-      }
-    },
-    {
-      "@id": "_:000027",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-36",
-      "isPartOf": {
-        "@id": "_:000028"
-      },
-      "name": "derivatives/sub-36",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 377833
-      }
-    },
-    {
-      "@id": "_:000028",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives",
-      "isPartOf": {
-        "@id": "_:000010"
-      },
-      "name": "derivatives",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 1124703
-      }
-    },
-    {
-      "@id": "_:000029",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-32/eeg",
-      "isPartOf": {
-        "@id": "_:000030"
-      },
-      "name": "derivatives/sub-32/eeg",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 371026
-      }
-    },
-    {
-      "@id": "_:000030",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-32",
-      "isPartOf": {
-        "@id": "_:000028"
-      },
-      "name": "derivatives/sub-32",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 371026
-      }
-    },
-    {
-      "@id": "_:000031",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-35/eeg",
-      "isPartOf": {
-        "@id": "_:000032"
-      },
-      "name": "derivatives/sub-35/eeg",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 375844
-      }
-    },
-    {
       "@id": "_:000032",
-      "@type": "https://openminds.ebrains.eu/core/FileBundle",
-      "contentDescription": "File bundle created for derivatives/sub-35",
+      "@type": "https://openminds.om-i.org/types/FileBundle",
+      "contentDescription": "File bundle created for sub-35/func",
       "isPartOf": {
-        "@id": "_:000028"
+        "@id": "_:000029"
       },
-      "name": "derivatives/sub-35",
+      "name": "sub-35/func",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
-        "value": 375844
+        "value": 0
       }
     },
     {
       "@id": "_:000033",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXacq-NODDI10DIR_dwi.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "593d08dc55d628832edf906948d06638"
         }
       ],
       "name": "acq-NODDI10DIR_dwi.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 271
       }
     },
     {
       "@id": "_:000034",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXacq-NODDI33DIR_dwi.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d5bfe26e13e1c579ddc7436e34696202"
         }
       ],
       "name": "acq-NODDI33DIR_dwi.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 269
       }
     },
     {
       "@id": "_:000035",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXacq-y224_T1w.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "20487c084ce56d29d32d73b8456ab7f1"
         }
       ],
       "name": "acq-y224_T1w.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 291
       }
     },
     {
       "@id": "_:000036",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXacq-y232_T1w.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "0ca1dcc9bf05b7744befb1458d82517a"
         }
       ],
       "name": "acq-y232_T1w.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 292
       }
     },
     {
       "@id": "_:000037",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXdataset_description.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "af4cfd0dc3fc6290b26910d2515b2907"
         }
       ],
       "name": "dataset_description.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 797
       }
     },
     {
       "@id": "_:000038",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXparticipants.tsv",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "3e95fd1a03d52c3b4a28c3a31dc97ec2"
         }
       ],
       "name": "participants.tsv",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 36
       }
     },
     {
       "@id": "_:000039",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/anat/sub-32_acq-y224_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 32",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000016"
+          "@id": "_:000025"
         }
       ],
       "name": "sub-32_acq-y224_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/DataType",
-      "definition": "'Voxel data' is a matrix defining values (scalars, lists, or matrices) on a grid in a three dimensional space, which can be rendered to raster graphic.",
-      "name": "voxel data"
-    },
-    {
       "@id": "_:000041",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/anat/sub-32_acq-y232_T1w.nii.gz",
       "contentDescription": "Data file for T1w of subject 32",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000016"
+          "@id": "_:000025"
         }
       ],
       "name": "sub-32_acq-y232_T1w.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000042",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI10DIR_dwi.bval",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "7a53a28c159b4040a4926be4f4b958dd"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000018"
+          "@id": "_:000023"
         }
       ],
       "name": "sub-32_acq-NODDI10DIR_dwi.bval",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 312
       }
     },
     {
       "@id": "_:000043",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI10DIR_dwi.bvec",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "0500182c4be4a6bc7a07cc103bc5b490"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000018"
+          "@id": "_:000023"
         }
       ],
       "name": "sub-32_acq-NODDI10DIR_dwi.bvec",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 1955
       }
     },
     {
       "@id": "_:000044",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI10DIR_dwi.nii.gz",
       "contentDescription": "Data file for dwi of subject 32",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000018"
+          "@id": "_:000023"
         }
       ],
       "name": "sub-32_acq-NODDI10DIR_dwi.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000045",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI33DIR_dwi.bval",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "eb27b25c7ec1760573fed3022bd52883"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000018"
+          "@id": "_:000023"
         }
       ],
       "name": "sub-32_acq-NODDI33DIR_dwi.bval",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 126
       }
     },
     {
       "@id": "_:000046",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI33DIR_dwi.bvec",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "cd9829e1c06bb69a07b39cf07bf3784a"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000018"
+          "@id": "_:000023"
         }
       ],
       "name": "sub-32_acq-NODDI33DIR_dwi.bvec",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 961
       }
     },
     {
       "@id": "_:000047",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-32/dwi/sub-32_acq-NODDI33DIR_dwi.nii.gz",
       "contentDescription": "Data file for dwi of subject 32",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000023"
+        }
+      ],
+      "name": "sub-32_acq-NODDI33DIR_dwi.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000048",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.eeg",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000026"
+        }
+      ],
+      "name": "sub-32_task-rest_eeg.eeg",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000049",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.vhdr",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "18e2fc3e80737f814eff9ea4102a9b56"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000026"
+        }
+      ],
+      "name": "sub-32_task-rest_eeg.vhdr",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 9091
+      }
+    },
+    {
+      "@id": "_:000050",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.vmrk",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "ed05ff43016d854033d4a5c6e1e9e3b6"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000026"
+        }
+      ],
+      "name": "sub-32_task-rest_eeg.vmrk",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 14976
+      }
+    },
+    {
+      "@id": "_:000051",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-32/func/sub-32_task-rest_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 32",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000027"
+        }
+      ],
+      "name": "sub-32_task-rest_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000052",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/anat/sub-35_acq-y224_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 35",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000030"
+        }
+      ],
+      "name": "sub-35_acq-y224_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000053",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/anat/sub-35_acq-y232_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 35",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000030"
+        }
+      ],
+      "name": "sub-35_acq-y232_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000054",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.bval",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "7a53a28c159b4040a4926be4f4b958dd"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI10DIR_dwi.bval",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 312
+      }
+    },
+    {
+      "@id": "_:000055",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.bvec",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "0500182c4be4a6bc7a07cc103bc5b490"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI10DIR_dwi.bvec",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 1955
+      }
+    },
+    {
+      "@id": "_:000056",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.nii.gz",
+      "contentDescription": "Data file for dwi of subject 35",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI10DIR_dwi.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000057",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.bval",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "eb27b25c7ec1760573fed3022bd52883"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI33DIR_dwi.bval",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 126
+      }
+    },
+    {
+      "@id": "_:000058",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.bvec",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "cd9829e1c06bb69a07b39cf07bf3784a"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI33DIR_dwi.bvec",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 961
+      }
+    },
+    {
+      "@id": "_:000059",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.nii.gz",
+      "contentDescription": "Data file for dwi of subject 35",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000028"
+        }
+      ],
+      "name": "sub-35_acq-NODDI33DIR_dwi.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000060",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.eeg",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000031"
+        }
+      ],
+      "name": "sub-35_task-rest_eeg.eeg",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000061",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.vhdr",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d716b77e43db1e133dce24c678ddb1cd"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000031"
+        }
+      ],
+      "name": "sub-35_task-rest_eeg.vhdr",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 9104
+      }
+    },
+    {
+      "@id": "_:000062",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.vmrk",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "c6d46448ce88354318adea49cbe279a1"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000031"
+        }
+      ],
+      "name": "sub-35_task-rest_eeg.vmrk",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 14828
+      }
+    },
+    {
+      "@id": "_:000063",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-35/func/sub-35_task-rest_bold.nii.gz",
+      "contentDescription": "Data file for bold of subject 35",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000032"
+        }
+      ],
+      "name": "sub-35_task-rest_bold.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000064",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-36/anat/sub-36_acq-y224_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 36",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000020"
+        }
+      ],
+      "name": "sub-36_acq-y224_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000065",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-36/anat/sub-36_acq-y232_T1w.nii.gz",
+      "contentDescription": "Data file for T1w of subject 36",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "d41d8cd98f00b204e9800998ecf8427e"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000020"
+        }
+      ],
+      "name": "sub-36_acq-y232_T1w.nii.gz",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
+      }
+    },
+    {
+      "@id": "_:000066",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.bval",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "7a53a28c159b4040a4926be4f4b958dd"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000018"
+        }
+      ],
+      "name": "sub-36_acq-NODDI10DIR_dwi.bval",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 312
+      }
+    },
+    {
+      "@id": "_:000067",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.bvec",
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
+          "algorithm": "MD5",
+          "digest": "0500182c4be4a6bc7a07cc103bc5b490"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@id": "_:000018"
+        }
+      ],
+      "name": "sub-36_acq-NODDI10DIR_dwi.bvec",
+      "storageSize": {
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
+        "unit": {
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 1955
+      }
+    },
+    {
+      "@id": "_:000068",
+      "@type": "https://openminds.om-i.org/types/File",
+      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.nii.gz",
+      "contentDescription": "Data file for dwi of subject 36",
+      "dataType": [
+        {
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
+        }
+      ],
+      "fileRepository": {
+        "@id": "_:000011"
+      },
+      "hash": [
+        {
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
@@ -838,958 +1456,331 @@
           "@id": "_:000018"
         }
       ],
-      "name": "sub-32_acq-NODDI33DIR_dwi.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000048",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.eeg",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000020"
-        }
-      ],
-      "name": "sub-32_task-rest_eeg.eeg",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000049",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.vhdr",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "18e2fc3e80737f814eff9ea4102a9b56"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000020"
-        }
-      ],
-      "name": "sub-32_task-rest_eeg.vhdr",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 9091
-      }
-    },
-    {
-      "@id": "_:000050",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-32/eeg/sub-32_task-rest_eeg.vmrk",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "ed05ff43016d854033d4a5c6e1e9e3b6"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000020"
-        }
-      ],
-      "name": "sub-32_task-rest_eeg.vmrk",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 14976
-      }
-    },
-    {
-      "@id": "_:000051",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-32/func/sub-32_task-rest_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 32",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000019"
-        }
-      ],
-      "name": "sub-32_task-rest_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000052",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/anat/sub-35_acq-y224_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 35",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000021"
-        }
-      ],
-      "name": "sub-35_acq-y224_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000053",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/anat/sub-35_acq-y232_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 35",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000021"
-        }
-      ],
-      "name": "sub-35_acq-y232_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000054",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.bval",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "7a53a28c159b4040a4926be4f4b958dd"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI10DIR_dwi.bval",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 312
-      }
-    },
-    {
-      "@id": "_:000055",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.bvec",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "0500182c4be4a6bc7a07cc103bc5b490"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI10DIR_dwi.bvec",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 1955
-      }
-    },
-    {
-      "@id": "_:000056",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI10DIR_dwi.nii.gz",
-      "contentDescription": "Data file for dwi of subject 35",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI10DIR_dwi.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000057",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.bval",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "eb27b25c7ec1760573fed3022bd52883"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI33DIR_dwi.bval",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 126
-      }
-    },
-    {
-      "@id": "_:000058",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.bvec",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "cd9829e1c06bb69a07b39cf07bf3784a"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI33DIR_dwi.bvec",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 961
-      }
-    },
-    {
-      "@id": "_:000059",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/dwi/sub-35_acq-NODDI33DIR_dwi.nii.gz",
-      "contentDescription": "Data file for dwi of subject 35",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000023"
-        }
-      ],
-      "name": "sub-35_acq-NODDI33DIR_dwi.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000060",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.eeg",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000025"
-        }
-      ],
-      "name": "sub-35_task-rest_eeg.eeg",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000061",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.vhdr",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d716b77e43db1e133dce24c678ddb1cd"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000025"
-        }
-      ],
-      "name": "sub-35_task-rest_eeg.vhdr",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 9104
-      }
-    },
-    {
-      "@id": "_:000062",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/eeg/sub-35_task-rest_eeg.vmrk",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "c6d46448ce88354318adea49cbe279a1"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000025"
-        }
-      ],
-      "name": "sub-35_task-rest_eeg.vmrk",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 14828
-      }
-    },
-    {
-      "@id": "_:000063",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-35/func/sub-35_task-rest_bold.nii.gz",
-      "contentDescription": "Data file for bold of subject 35",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000024"
-        }
-      ],
-      "name": "sub-35_task-rest_bold.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000064",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-36/anat/sub-36_acq-y224_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 36",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000008"
-        }
-      ],
-      "name": "sub-36_acq-y224_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000065",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-36/anat/sub-36_acq-y232_T1w.nii.gz",
-      "contentDescription": "Data file for T1w of subject 36",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000008"
-        }
-      ],
-      "name": "sub-36_acq-y232_T1w.nii.gz",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
-      }
-    },
-    {
-      "@id": "_:000066",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.bval",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "7a53a28c159b4040a4926be4f4b958dd"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000013"
-        }
-      ],
-      "name": "sub-36_acq-NODDI10DIR_dwi.bval",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 312
-      }
-    },
-    {
-      "@id": "_:000067",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.bvec",
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "0500182c4be4a6bc7a07cc103bc5b490"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000013"
-        }
-      ],
-      "name": "sub-36_acq-NODDI10DIR_dwi.bvec",
-      "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
-        "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        },
-        "value": 1955
-      }
-    },
-    {
-      "@id": "_:000068",
-      "@type": "https://openminds.ebrains.eu/core/File",
-      "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI10DIR_dwi.nii.gz",
-      "contentDescription": "Data file for dwi of subject 36",
-      "dataType": [
-        {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
-        }
-      ],
-      "fileRepository": {
-        "@id": "_:000010"
-      },
-      "hash": [
-        {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
-          "algorithm": "MD5",
-          "digest": "d41d8cd98f00b204e9800998ecf8427e"
-        }
-      ],
-      "isPartOf": [
-        {
-          "@id": "_:000013"
-        }
-      ],
       "name": "sub-36_acq-NODDI10DIR_dwi.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000069",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI33DIR_dwi.bval",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "eb27b25c7ec1760573fed3022bd52883"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000013"
+          "@id": "_:000018"
         }
       ],
       "name": "sub-36_acq-NODDI33DIR_dwi.bval",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 126
       }
     },
     {
       "@id": "_:000070",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI33DIR_dwi.bvec",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "cd9829e1c06bb69a07b39cf07bf3784a"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000013"
+          "@id": "_:000018"
         }
       ],
       "name": "sub-36_acq-NODDI33DIR_dwi.bvec",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 961
       }
     },
     {
       "@id": "_:000071",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/dwi/sub-36_acq-NODDI33DIR_dwi.nii.gz",
       "contentDescription": "Data file for dwi of subject 36",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000013"
+          "@id": "_:000018"
         }
       ],
       "name": "sub-36_acq-NODDI33DIR_dwi.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000072",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/eeg/sub-36_task-rest_eeg.eeg",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000015"
+          "@id": "_:000021"
         }
       ],
       "name": "sub-36_task-rest_eeg.eeg",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000073",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/eeg/sub-36_task-rest_eeg.vhdr",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8386437d1878f8585ae6d50c5d931c6a"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000015"
+          "@id": "_:000021"
         }
       ],
       "name": "sub-36_task-rest_eeg.vhdr",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 9091
       }
     },
     {
       "@id": "_:000074",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/eeg/sub-36_task-rest_eeg.vmrk",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "8ec29017240c4d67972cb160dabf2270"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000015"
+          "@id": "_:000021"
         }
       ],
       "name": "sub-36_task-rest_eeg.vmrk",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 13681
       }
     },
     {
       "@id": "_:000075",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXsub-36/func/sub-36_task-rest_bold.nii.gz",
       "contentDescription": "Data file for bold of subject 36",
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/dataType/voxelData"
+          "@id": "https://openminds.om-i.org/instances/dataType/voxelData"
         }
       ],
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "d41d8cd98f00b204e9800998ecf8427e"
         }
       ],
       "isPartOf": [
         {
-          "@id": "_:000014"
+          "@id": "_:000022"
         }
       ],
       "name": "sub-36_task-rest_bold.nii.gz",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
-        }
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
+        },
+        "value": 0
       }
     },
     {
       "@id": "_:000076",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXtask-rest_bold.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "9890c2521e2b4f3225615f14a3432557"
         }
       ],
       "name": "task-rest_bold.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 609
       }
     },
     {
       "@id": "_:000077",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXtask-rest_eeg.json",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "51a6fe4d025f6f90da8ef37fb0d06b02"
         }
       ],
       "name": "task-rest_eeg.json",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 457
       }
     },
     {
       "@id": "_:000078",
-      "@type": "https://openminds.ebrains.eu/core/File",
+      "@type": "https://openminds.om-i.org/types/File",
       "IRI": "PREFIXREADME",
       "fileRepository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "hash": [
         {
-          "@type": "https://openminds.ebrains.eu/core/Hash",
+          "@type": "https://openminds.om-i.org/types/Hash",
           "algorithm": "MD5",
           "digest": "920ae0482860f26318cc75a014512842"
         }
       ],
       "name": "README",
       "storageSize": {
-        "@type": "https://openminds.ebrains.eu/core/QuantitativeValue",
+        "@type": "https://openminds.om-i.org/types/QuantitativeValue",
         "unit": {
-          "@id": "https://openminds.ebrains.eu/instances/unitOfMeasurement/byte"
+          "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte"
         },
         "value": 254
       }
     },
     {
       "@id": "_:000079",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Deligianni",
       "givenName": "F."
     },
     {
       "@id": "_:000080",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Centeno",
       "givenName": "M."
     },
     {
       "@id": "_:000081",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Carmichael",
       "givenName": "D.W."
     },
     {
       "@id": "_:000082",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Zhang",
       "givenName": "G.H."
     },
     {
       "@id": "_:000083",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Clark",
       "givenName": "C.A."
     },
     {
       "@id": "_:000084",
-      "@type": "https://openminds.ebrains.eu/core/Person",
+      "@type": "https://openminds.om-i.org/types/Person",
       "familyName": "Clayden",
       "givenName": "J.D."
     },
     {
       "@id": "_:000085",
-      "@type": "https://openminds.ebrains.eu/core/DatasetVersion",
+      "@type": "https://openminds.om-i.org/types/DatasetVersion",
       "author": [
         {
           "@id": "_:000079"
@@ -1817,26 +1808,26 @@
       ],
       "dataType": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/semanticDataType/rawData"
+          "@id": "https://openminds.om-i.org/instances/semanticDataType/rawData"
         }
       ],
       "experimentalApproach": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuroimaging"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/anatomy"
         },
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuralConnectivity"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuralConnectivity"
         },
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/anatomy"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/electrophysiology"
         },
         {
-          "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/electrophysiology"
+          "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuroimaging"
         }
       ],
       "fullName": "EEG, fMRI and NODDI at rest'",
       "repository": {
-        "@id": "_:000010"
+        "@id": "_:000011"
       },
       "shortName": "EEG, fMRI and NODDI at rest'",
       "studiedSpecimen": [
@@ -1852,66 +1843,16 @@
       ],
       "technique": [
         {
-          "@id": "https://openminds.ebrains.eu/instances/technique/diffusionWeightedImaging"
+          "@id": "https://openminds.om-i.org/instances/technique/diffusionWeightedImaging"
         },
         {
-          "@id": "https://openminds.ebrains.eu/instances/technique/electroencephalography"
+          "@id": "https://openminds.om-i.org/instances/technique/electroencephalography"
         }
       ]
     },
     {
-      "@id": "https://openminds.ebrains.eu/instances/semanticDataType/rawData",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/SemanticDataType",
-      "name": "raw data"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuroimaging",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on the non-invasive direct or indirect imaging of the structure, function, or pharmacology of the nervous system.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
-      "name": "neuroimaging",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Neuroimaging"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/neuralConnectivity",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on functional or anatomical connections between single neurons or populations of neurons in defined anatomical regions.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739393",
-      "name": "neural connectivity",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Connectivity"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/anatomy",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on the bodily structure of living organisms.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
-      "name": "anatomy",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Anatomy",
-      "synonym": [
-        "anatomical approach"
-      ]
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/experimentalApproach/electrophysiology",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/ExperimentalApproach",
-      "definition": "Any experimental approach focused on electrical phenomena associated with living systems, most notably the nervous system, cardiac system, and musculoskeletal system.",
-      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741202",
-      "name": "electrophysiology",
-      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Electrophysiology"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/technique/diffusionWeightedImaging",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/Technique",
-      "name": "diffusion-weighted imaging"
-    },
-    {
-      "@id": "https://openminds.ebrains.eu/instances/technique/electroencephalography",
-      "@type": "https://openminds.ebrains.eu/controlledTerms/Technique",
-      "name": "electroencephalography"
-    },
-    {
       "@id": "_:000093",
-      "@type": "https://openminds.ebrains.eu/core/Dataset",
+      "@type": "https://openminds.om-i.org/types/Dataset",
       "author": [
         {
           "@id": "_:000079"
@@ -1939,6 +1880,89 @@
         }
       ],
       "shortName": "EEG, fMRI and NODDI at rest'"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/contentTypes/application_vnd.bids",
+      "@type": "https://openminds.om-i.org/types/ContentType",
+      "name": "application/vnd.bids",
+      "synonym": [
+        "BIDS"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/dataType/voxelData",
+      "@type": "https://openminds.om-i.org/types/DataType",
+      "definition": "'Voxel data' is a matrix defining values (scalars, lists, or matrices) on a grid in a three dimensional space, which can be rendered to raster graphic.",
+      "name": "voxel data"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/anatomy",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on the bodily structure of living organisms.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739411",
+      "name": "anatomy",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Anatomy",
+      "synonym": [
+        "anatomical approach"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/electrophysiology",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on electrical phenomena associated with living systems, most notably the nervous system, cardiac system, and musculoskeletal system.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741202",
+      "name": "electrophysiology",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Electrophysiology"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuralConnectivity",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on functional or anatomical connections between single neurons or populations of neurons in defined anatomical regions.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0739393",
+      "name": "neural connectivity",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Connectivity"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/experimentalApproach/neuroimaging",
+      "@type": "https://openminds.om-i.org/types/ExperimentalApproach",
+      "definition": "Any experimental approach focused on the non-invasive direct or indirect imaging of the structure, function, or pharmacology of the nervous system.",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0741206",
+      "name": "neuroimaging",
+      "preferredOntologyIdentifier": "http://uri.interlex.org/tgbugs/uris/readable/modality/Neuroimaging"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/semanticDataType/rawData",
+      "@type": "https://openminds.om-i.org/types/SemanticDataType",
+      "name": "raw data"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/species/homoSapiens",
+      "@type": "https://openminds.om-i.org/types/Species",
+      "definition": "The species *Homo sapiens* (humans) belongs to the family of *hominidae* (great apes).",
+      "interlexIdentifier": "http://uri.interlex.org/base/ilx_0105114",
+      "knowledgeSpaceLink": "https://knowledge-space.org/wiki/NCBITaxon:9606#human",
+      "name": "Homo sapiens",
+      "preferredOntologyIdentifier": "http://purl.obolibrary.org/obo/NCBITaxon_9606",
+      "synonym": [
+        "homo sapien",
+        "human",
+        "man"
+      ]
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/technique/diffusionWeightedImaging",
+      "@type": "https://openminds.om-i.org/types/Technique",
+      "name": "diffusion-weighted imaging"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/technique/electroencephalography",
+      "@type": "https://openminds.om-i.org/types/Technique",
+      "name": "electroencephalography"
+    },
+    {
+      "@id": "https://openminds.om-i.org/instances/unitOfMeasurement/byte",
+      "@type": "https://openminds.om-i.org/types/UnitOfMeasurement",
+      "name": "byte"
     }
   ]
 }

--- a/test/test_bids_examples.py
+++ b/test/test_bids_examples.py
@@ -19,7 +19,7 @@ def test_example_datasets(dataset_label, dataset_subject_number, dataset_subject
     test_dir = os.path.join("bids-examples", dataset_label)
     bids2openminds.converter.convert(test_dir, save_output=True)
     c = Collection()
-    c.load(os.path.join(test_dir, "openminds.jsonld"), version="v3")
+    c.load(os.path.join(test_dir, "openminds.jsonld"), version="v4")
 
     subject_number = 0
     subject_state_number = 0
@@ -30,18 +30,18 @@ def test_example_datasets(dataset_label, dataset_subject_number, dataset_subject
     subject_state_number_besed_on_subject = 0
 
     for item in c:
-        if item.type_ == "https://openminds.ebrains.eu/core/Subject":
+        if item.type_ == "https://openminds.om-i.org/types/Subject":
             subject_number += 1
             subject_state_number_besed_on_subject += len(item.studied_states)
-        if item.type_ == "https://openminds.ebrains.eu/core/SubjectState":
+        if item.type_ == "https://openminds.om-i.org/types/SubjectState":
             subject_state_number += 1
-        if item.type_ == "https://openminds.ebrains.eu/core/Person":
+        if item.type_ == "https://openminds.om-i.org/types/Person":
             person_number += 1
-        if item.type_ == "https://openminds.ebrains.eu/core/File":
+        if item.type_ == "https://openminds.om-i.org/types/File":
             files_number += 1
-        if item.type_ == "https://openminds.ebrains.eu/core/FileBundle":
+        if item.type_ == "https://openminds.om-i.org/types/FileBundle":
             file_bundles_number += 1
-        if item.type_ == "https://openminds.ebrains.eu/core/BehavioralProtocol":
+        if item.type_ == "https://openminds.om-i.org/types/BehavioralProtocol":
             behavioral_protocol_number += 1
 
     assert dataset_subject_number == subject_number

--- a/test/test_example_datasets_click.py
+++ b/test/test_example_datasets_click.py
@@ -13,7 +13,7 @@ def test_example_datasets_click():
     result = runner.invoke(convert_click, [test_dir])
     assert result.exit_code == 0
     c = Collection()
-    c.load(os.path.join(test_dir, "openminds.jsonld"), version="v3")
+    c.load(os.path.join(test_dir, "openminds.jsonld"), version="v4")
 
 
 def test_example_datasets_click_seperate_files():
@@ -36,4 +36,4 @@ def test_example_datasets_click_output_location():
         convert_click, ["-o", openminds_file, test_dir])
     assert result.exit_code == 0
     c = Collection()
-    c.load(openminds_file, version="v3")
+    c.load(openminds_file, version="v4")

--- a/test/test_file_bundle.py
+++ b/test/test_file_bundle.py
@@ -50,7 +50,7 @@ def test_number_file_bundle(generate_file_bundle_collection):
     _, collection, _ = generate_file_bundle_collection
     m = 0
     for item in collection:
-        if item.type_ == "https://openminds.ebrains.eu/core/FileBundle":
+        if item.type_ == "https://openminds.om-i.org/types/FileBundle":
             m += 1
     assert m == number_of_openminds_bundle
 
@@ -82,7 +82,7 @@ def test_random_folder(test_dir, path_list, bundle, parent_bundle, generate_file
     dataset_bundle = None
 
     for item in collection:
-        if item.type_ == "https://openminds.ebrains.eu/core/FileBundle" and item.name == folder_name:
+        if item.type_ == "https://openminds.om-i.org/types/FileBundle" and item.name == folder_name:
             # detects only one file bundle have this name
             assert dataset_bundle is None
             dataset_bundle = item
@@ -94,5 +94,5 @@ def test_random_folder(test_dir, path_list, bundle, parent_bundle, generate_file
     if parent_bundle is not None:
         assert dataset_bundle.is_part_of.name == parent_bundle[0]
     else:
-        assert dataset_bundle.is_part_of.type_ == "https://openminds.ebrains.eu/core/FileRepository"
+        assert dataset_bundle.is_part_of.type_ == "https://openminds.om-i.org/types/FileRepository"
         assert dataset_bundle.is_part_of.iri.value == file_repository_iri

--- a/test/test_person.py
+++ b/test/test_person.py
@@ -1,7 +1,7 @@
 # test for create_openminds_person function in the main
 import pytest
 from bids2openminds.main import create_openminds_person
-import openminds.v3.core as omcore
+import openminds.v4.core as omcore
 
 # Test data: (full_name, given_name, family_name)
 example_names = [("John Ronald Reuel Tolkien", "John Ronald Reuel", "Tolkien"),

--- a/test/test_subject_age.py
+++ b/test/test_subject_age.py
@@ -11,11 +11,11 @@ def test_subject_age(age, age_type):
     data_subject_table = pd.DataFrame(data={'age': [age]})
     openminds_age = create_openminds_age(data_subject_table)
     if age_type == "QuantitativeValueRange":
-        assert openminds_age.type_ == 'https://openminds.ebrains.eu/core/QuantitativeValueRange'
+        assert openminds_age.type_ == 'https://openminds.om-i.org/types/QuantitativeValueRange'
         assert openminds_age.max_value is None
         assert openminds_age.min_value == 89
     if age_type == "QuantitativeValue":
-        assert openminds_age.type_ == 'https://openminds.ebrains.eu/core/QuantitativeValue'
+        assert openminds_age.type_ == 'https://openminds.om-i.org/types/QuantitativeValue'
         assert openminds_age.value == age
     if age_type == None:
         assert openminds_age is None

--- a/test/test_thorough_bids_example.py
+++ b/test/test_thorough_bids_example.py
@@ -31,12 +31,12 @@ def load_collections():
             file.write(actual_data)
 
         reference_collection = Collection()
-        reference_collection.load(tempdir+test_standard_name, version="v3")
+        reference_collection.load(tempdir+test_standard_name, version="v4")
 
         bids2openminds.converter.convert(test_dataset, save_output=True)
         generated_collection = Collection()
         generated_collection.load(os.path.join(
-            test_dataset, "openminds.jsonld"), version="v3")
+            test_dataset, "openminds.jsonld"), version="v4")
 
         collections[dataset_label] = (
             reference_collection, generated_collection)
@@ -46,7 +46,7 @@ def load_collections():
 
 
 def detect_type(collection, type):
-    type_IRI = "https://openminds.ebrains.eu/core/" + type
+    type_IRI = "https://openminds.om-i.org/types/" + type
     items_list = []
     for item in collection:
         if item.type_ == type_IRI:
@@ -164,6 +164,6 @@ def test_file_bundle(load_collections, dataset_label):
         generated_file_bundle = find_name(
             refrence_file_bundle.name, generated_file_bundles)
         assert generated_file_bundle is not None
-        if refrence_file_bundle.is_part_of.type_ == "https://openminds.ebrains.eu/core/FileBundle":
-            assert generated_file_bundle.is_part_of.type_ == "https://openminds.ebrains.eu/core/FileBundle"
+        if refrence_file_bundle.is_part_of.type_ == "https://openminds.om-i.org/types/FileBundle":
+            assert generated_file_bundle.is_part_of.type_ == "https://openminds.om-i.org/types/FileBundle"
             assert refrence_file_bundle.is_part_of.name == generated_file_bundle.is_part_of.name


### PR DESCRIPTION
## Summary

- Updates imports in `bids2openminds/main.py` and `utility.py` from `openminds.v3` to `openminds.v4`
- Updates `Collection.load()` calls in tests to use `version="v4"`
- Replaces hardcoded v3 type/instance URLs (`openminds.ebrains.eu`) with v4 URLs (`openminds.om-i.org`) across test files
- Regenerates the reference JSON-LD fixtures (`test/bids_examples_*.jsonld`) with v4 output