### PR TITLE
Replace pybids with ancpBIDS

### DIFF
--- a/bids2openminds/converter.py
+++ b/bids2openminds/converter.py
@@ -1,11 +1,61 @@
 import warnings
-from bids import BIDSLayout, BIDSValidator
-from openminds import Collection
 import os
+import pandas as pd
+from ancpbids import BIDSLayout
+from ancpbids.query import Artifact
+from ancpbids.model_base import DatatypeFolder
+from openminds import Collection
 import click
 from . import main
 from . import utility
 from . import report
+
+_ENTITY_RENAMES = {"sub": "subject", "ses": "session"}
+
+# Root-level BIDS files that ancpBIDS does not expose as Artifacts
+_ROOT_BIDS_FILES = [
+    ("dataset_description.json", "description", ".json"),
+    ("participants.tsv", "participants", ".tsv"),
+    ("participants.json", "participants", ".json"),
+    ("CHANGES", None, None),
+    ("README", None, None),
+    ("README.md", None, None),
+]
+
+
+def layout_to_df(layout):
+    dataset = layout.get_dataset()
+    rows = []
+
+    for obj in layout.get(return_type='object', scope='raw'):
+        if not isinstance(obj, Artifact):
+            continue
+        parent = obj.get_parent()
+        datatype = parent.name if isinstance(parent, DatatypeFolder) else None
+        row = {
+            "path": obj.get_absolute_path(),
+            "suffix": obj.suffix,
+            "datatype": datatype,
+            "extension": obj.extension,
+        }
+        for entity in obj.entities:
+            key = _ENTITY_RENAMES.get(entity.key, entity.key)
+            row[key] = entity.value
+        rows.append(row)
+
+    base_dir = os.path.abspath(dataset.base_dir_)
+    for fname, suffix, extension in _ROOT_BIDS_FILES:
+        path = os.path.join(base_dir, fname)
+        if not os.path.exists(path):
+            continue
+        row = {"path": path, "datatype": None}
+        if suffix is not None:
+            row["suffix"] = suffix
+        if extension is not None:
+            row["extension"] = extension
+        rows.append(row)
+
+    return pd.DataFrame(rows)
 
 
 def convert(input_path,  save_output=False, output_path=None, multiple_files=False, include_empty_properties=False, quiet=False):
@@ -23,7 +73,7 @@ def convert(input_path,  save_output=False, output_path=None, multiple_files=Fal
     collection = Collection()
     bids_layout = BIDSLayout(input_path)
 
-    layout_df = bids_layout.to_df()
+    layout_df = layout_to_df(bids_layout)
 
     subjects_id = bids_layout.get_subjects()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 name = "bids2openminds"
 version = "0.1.1"
 dependencies = [
-  "bids-validator == 1.14.6" ,
-  "bids",
+  "ancpbids",
   "openminds >= 0.2.3",
   "click>=8.1",
   "pandas",

--- a/test/test_bids_examples.py
+++ b/test/test_bids_examples.py
@@ -6,7 +6,9 @@ import bids2openminds.converter
 
 # Dataset information in following order dataset_label, dataset_subject_number, dataset_subject_state_number, dataset_person_number, dataset_files_number, dataset_file_bundles_number, dataset_behavioral_protocol_number
 example_dataset = [("ds003", 13, 13, 2, 58, 39, 1),
-                   ("ds000247", 6, 10, 5, 202, 41, 2),
+                   # ancpBIDS treats CTF MEG .ds directories as single artifacts (not their internal files),
+                   # so file count is lower than with pybids (which listed each file inside .ds separately)
+                   ("ds000247", 6, 10, 5, 120, 41, 2),
                    # The authors list in 'eeg_cbm' contains non person entities 2 is not correct name (issue raied #43)
                    ("eeg_cbm", 20, 20, 2, 104, 40, 1),
                    ("asl001", 1, 1, 2, 8, 3, 0),

--- a/test/test_task.py
+++ b/test/test_task.py
@@ -1,5 +1,5 @@
 import pytest
-from bids import BIDSLayout
+from ancpbids import BIDSLayout
 from openminds import Collection
 import os
 from bids2openminds.main import create_behavioral_protocol


### PR DESCRIPTION
**Summary**

Following on from the discussion in #69, this PR replaces pybids with ancpBIDS as the BIDS layout engine. This is a prerequisite for using ancpBIDS's metadata inheritance engine (`get_metadata()`) to generate in-depth neuroimaging metadata in a future PR.

A `layout_to_df()` shim in `converter.py` bridges the ancpBIDS native API to the pandas `DataFrame` expected by the rest of the pipeline, so `main.py` and `utility.py` are unchanged. In future, we could drop the DataFrame interface, if it seems like a good idea.

Of the two motivations for replacing pybids mentioned in #69, this PR deals with "a lot of additional dependencies we don't need", and lays the groundwork for "does not extract all the things we need".

**Dependency changes**

pybids (main): 33 packages
ancpBIDS (this branch): 18 packages

Packages dropped entirely:

| Removed | Purpose |
| --- | --- |
| pybids 0.17.2                   | the layout engine itself      |
| bids-validator 1.14.6           | unused validator              |
| SQLAlchemy 2.0.49               | pybids database backend       |
| nibabel 5.4.2                   | pybids NIfTI reading          |
| scipy 1.17.1                    | pulled in by pybids           |
| formulaic 0.5.2                 | pybids formula parsing        |
| fsspec 2026.4.0                 | pybids filesystem abstraction |
| astor 0.8.1                     | pybids AST rewriting          |
| docopt 0.6.2                    | bids-validator CLI            |
| interface_meta 2.0.1            | formulaic dependency          |
| num2words 0.5.14                | pybids dependency             |
| pathlib_abc / universal_pathlib | fsspec dependencies           |
| typing_extensions               | pybids compatibility shim     |
| wrapt 1.1.3                     | decorator library             |

